### PR TITLE
Enhancement/movecancelbutton

### DIFF
--- a/ThemeCreatorMudBlazor.UI/Components/Pages/About.razor
+++ b/ThemeCreatorMudBlazor.UI/Components/Pages/About.razor
@@ -31,6 +31,8 @@
                 ChangeWhat: "Updated Color Picker component to MudExDialog making it draggable. Added palette icon options in place of button to copy from existing Primary, Secondary, or Tertiary colors.", ChangeWhy: "Feature Request" ),
                 new ChangeLogItem(ChangeWhen: DateTime.Parse("2024-10-11"), ChangeWho: "Jilael",
                 ChangeWhat: "Fixed timing issue in Snackbarchip, specifically in async operations where the chip is supposed to show after some operation is done.", ChangeWhy: "Bug Fix, SnackbarChip" ),
+                new ChangeLogItem(ChangeWhen: DateTime.Parse("2024-10-12"), ChangeWho: "Jilael",
+                ChangeWhat: "Realigned header actions buttons on Color Picker component", ChangeWhy: "Enhancement" ),
                     ];
                 }
                 <ul class="px-6 py-1">

--- a/ThemeCreatorMudBlazor.UI/Components/ThemeCreatorColorItem.razor
+++ b/ThemeCreatorMudBlazor.UI/Components/ThemeCreatorColorItem.razor
@@ -3,8 +3,8 @@
 <div class="mud-list-item-clickable mud-ripple pr-4 py-3" @onclick="ToggleOpen" data-tooltip="@ToolTipText">
     <MudStack Row AlignItems="AlignItems.Center" Class="pl-0 ml-0">
         <!-- TODO Link tooltip somehow -->
-        <MudText Typo="Typo.body2" Class="left-text">@Name</MudText>
-        <MudIcon Class="palette-picker-icon" Icon="@Icons.Material.Filled.Palette" Style="@($"color: {DefaultColor}")" Size="Size.Small" />
+            <MudText Typo="Typo.body2" Class="left-text">@Name</MudText>
+            <MudIcon Class="palette-picker-icon" Icon="@Icons.Material.Filled.Palette" Style="@($"color: {DefaultColor}")" Size="Size.Small" />
     </MudStack>
 </div>
 <!-- Tryblazor version: https://try.mudblazor.com/snippet/wkGybuaSrnvujsOP -->
@@ -13,18 +13,19 @@
     <TitleContent>
         <MudStack Class="ma-0 pa-0 mt-n1 mb-1 mr-n1" Row AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween">
             <MudText Style="max-width: 190px; user-select: none;" Class="left-text" Typo="Typo.h6">Edit @Name</MudText>
-            <MudStack Row Spacing="0" Justify="Justify.FlexEnd">
+            <MudStack Row Spacing="1" Justify="Justify.FlexEnd">                
                 <MudTooltip Text="Copy Color to Clipboard">
                     <SnackbarChip @ref="copyColorSnackbarChip" IconToShow="@Icons.Material.Filled.ContentCopy" OnClick="@CopyColor" />
                 </MudTooltip>
                 <MudTooltip Text="Paste Color from Clipboard">
                     <SnackbarChip @ref="pasteColorSnackbarChip" IconToShow="@Icons.Material.Filled.ContentPaste" OnClick="@PasteColor" />
                 </MudTooltip>
-                <MudTooltip Text="Revert to original color">
-                    <MudIconButton Size="Size.Small" Icon="@Icons.Material.Filled.Cancel" OnClick="@CancelOpen" />
-                </MudTooltip>
+                &nbsp;
                 <MudTooltip Text="Save Changes">
                     <MudIconButton Size="Size.Small" Icon="@Icons.Material.Filled.Save" OnClick="@ToggleOpen" />
+                </MudTooltip>                
+                <MudTooltip Text="Revert to original color">
+                    <MudIconButton Size="Size.Small" Icon="@Icons.Material.Outlined.Cancel" OnClick="@CancelOpen" />
                 </MudTooltip>
             </MudStack>
         </MudStack>


### PR DESCRIPTION
Solves #5 by moving the Cancel button to the right, changing it to a slightly different style button. I adding spacing between all buttons in header actions and an extra space separating Save from Cancel. Clicking outside the Dialog still causes changes to be saved.
Old
![Screenshot 2024-10-12 200924](https://github.com/user-attachments/assets/4e782e65-36c0-4464-84f4-63a30d83426f)
New
![Screenshot 2024-10-12 200909](https://github.com/user-attachments/assets/f3ec4a59-3a5e-436d-8e1d-aba4a4b1b54f)